### PR TITLE
docs: add automated Swagger API documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ A robust, production-grade backend service for the Enxero Platform built with Ne
   - Robust error handling (NotFound, Conflict, BadRequest, relation/uniqueness errors)
 - **Comprehensive E2E Test Coverage**
   - All modules and endpoints are covered by automated E2E tests (CRUD, validation, edge cases, error handling)
+- **Automated API Documentation**
+  - Swagger UI at `/api` (non-production) with live, interactive docs for all endpoints
+  - Bearer authentication supported in Swagger
 - **Modular Architecture**
   - All core modules from the ExpressJS version, now in a modular NestJS structure
 
@@ -183,7 +186,11 @@ A robust, production-grade backend service for the Enxero Platform built with Ne
 
 ## 📖 API Documentation
 
-- Swagger/OpenAPI docs available at `/api` (if enabled in main.ts)
+- **Swagger UI:**
+  - Available at [`/api`](http://localhost:3000/api) when running in non-production environments
+  - Interactive documentation for all endpoints, including request/response schemas
+  - Bearer authentication supported for testing secured endpoints
+  - Docs are auto-generated from code and DTOs—keep them up to date by maintaining your controllers and DTOs
 
 ## 🤝 Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@nestjs/config": "^4.0.2",
         "@nestjs/core": "^11.0.1",
         "@nestjs/platform-express": "^11.0.1",
+        "@nestjs/swagger": "^11.2.0",
         "@prisma/client": "^6.10.1",
         "bcryptjs": "^3.0.2",
         "class-transformer": "^0.5.1",
@@ -20,6 +21,7 @@
         "prisma": "^6.10.1",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "swagger-ui-express": "^5.0.1",
         "uuid": "^11.1.0"
       },
       "devDependencies": {
@@ -1713,6 +1715,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.15.1.tgz",
+      "integrity": "sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw=="
+    },
     "node_modules/@napi-rs/nice": {
       "version": "1.0.1",
       "dev": true,
@@ -2275,6 +2282,25 @@
         }
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-2.1.0.tgz",
+      "integrity": "sha512-W+n+rM69XsFdwORF11UqJahn4J3xi4g/ZEOlJNL6KoW5ygWSmBB2p0S2BZ4FQeS/NDH72e6xIcu35SfJnE8bXw==",
+      "peerDependencies": {
+        "@nestjs/common": "^10.0.0 || ^11.0.0",
+        "class-transformer": "^0.4.0 || ^0.5.0",
+        "class-validator": "^0.13.0 || ^0.14.0",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "11.1.3",
       "license": "MIT",
@@ -2378,6 +2404,38 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-11.2.0.tgz",
+      "integrity": "sha512-5wolt8GmpNcrQv34tIPUtPoV1EeFbCetm40Ij3+M0FNNnf2RJ3FyWfuQvI8SBlcJyfaounYVTKzKHreFXsUyOg==",
+      "dependencies": {
+        "@microsoft/tsdoc": "0.15.1",
+        "@nestjs/mapped-types": "2.1.0",
+        "js-yaml": "4.1.0",
+        "lodash": "4.17.21",
+        "path-to-regexp": "8.2.0",
+        "swagger-ui-dist": "5.21.0"
+      },
+      "peerDependencies": {
+        "@fastify/static": "^8.0.0",
+        "@nestjs/common": "^11.0.1",
+        "@nestjs/core": "^11.0.1",
+        "class-transformer": "*",
+        "class-validator": "*",
+        "reflect-metadata": "^0.1.12 || ^0.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@fastify/static": {
+          "optional": true
+        },
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nestjs/testing": {
@@ -2557,6 +2615,12 @@
       "dependencies": {
         "@prisma/debug": "6.10.1"
       }
+    },
+    "node_modules/@scarf/scarf": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.4.0.tgz",
+      "integrity": "sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==",
+      "hasInstallScript": true
     },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
@@ -4238,7 +4302,6 @@
     },
     "node_modules/argparse": {
       "version": "2.0.1",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/array-timsort": {
@@ -7362,7 +7425,6 @@
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -9333,6 +9395,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/swagger-ui-dist": {
+      "version": "5.21.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-5.21.0.tgz",
+      "integrity": "sha512-E0K3AB6HvQd8yQNSMR7eE5bk+323AUxjtCz/4ZNKiahOlPhPJxqn3UPIGs00cyY/dhrTDJ61L7C/a8u6zhGrZg==",
+      "dependencies": {
+        "@scarf/scarf": "=1.4.0"
+      }
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
+      "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "dependencies": {
+        "swagger-ui-dist": ">=5.0.0"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0 || >=5.0.0-beta"
       }
     },
     "node_modules/symbol-observable": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@nestjs/config": "^4.0.2",
     "@nestjs/core": "^11.0.1",
     "@nestjs/platform-express": "^11.0.1",
+    "@nestjs/swagger": "^11.2.0",
     "@prisma/client": "^6.10.1",
     "bcryptjs": "^3.0.2",
     "class-transformer": "^0.5.1",
@@ -31,6 +32,7 @@
     "prisma": "^6.10.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "swagger-ui-express": "^5.0.1",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,21 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  if (process.env.NODE_ENV !== 'production') {
+    const config = new DocumentBuilder()
+      .setTitle('Enxero Platform API')
+      .setDescription('API documentation for the Enxero Platform')
+      .setVersion('1.0')
+      .addBearerAuth()
+      .build();
+    const document = SwaggerModule.createDocument(app, config);
+    SwaggerModule.setup('api', app, document);
+  }
+
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();


### PR DESCRIPTION
- Documented Swagger UI at /api for live, interactive API docs (non-production)
- Added details on Bearer authentication support in Swagger
- Updated Features and API Documentation sections to reflect automated, up-to-date OpenAPI docs